### PR TITLE
Fix mu error and strength distribution

### DIFF
--- a/tournament.wppl
+++ b/tournament.wppl
@@ -1,6 +1,6 @@
 // set the memoized core strength of each team, regardless of match played
 var strengthCore = mem(function (team) {
-  return Math.abs(gaussian({mu: 2.0, sigma: 1.0}));
+  return Math.max(gaussian({mu: 2.0, sigma: 1.0}), 0.001);
 });
 
 // set the memoized strength of each team for a specific match index, modifying the core strength
@@ -8,7 +8,7 @@ var strengthCore = mem(function (team) {
 var strengthMatch = mem(function (team, match) {
   return team === 'none' ?
     0 :
-    strengthCore(team) + gaussian({mu: 0.5, sigma: 0.2});
+    Math.max(strengthCore(team) + gaussian({mu: 0.5, sigma: 0.2}),0.001);
 });
 
 // to evaluate the strength of a team vector, get the match strength of the team represented by the vector


### PR DESCRIPTION
- mu must be >0, so force it using max
- large negative strenth values were flipped to large positive strength and I think (but not positive) a more accurate disribution would be to floor them near zero, which this change also does